### PR TITLE
Use OpenSIPS/SIPssert/actions.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,33 +13,8 @@ jobs:
 
     steps:
 
-    - name: Checkout SIPssert repo
-      uses: actions/checkout@v3
-      with:
-        repository: 'OpenSIPS/SIPssert'
-        path: sipssert
-
-    - name: Install SIPssert
-      working-directory: sipssert
-      run: python3 setup.py install --user clean
-
-    - name: Checkout Tests repo
-      uses: actions/checkout@v3
-      with:
-        path: tests
+    - name: Prepare SIPssert
+      uses: sobomax/SIPssert/actions/Prepare_SIPssert@main
 
     - name: Run All Tests
-      working-directory: tests
-      run: ./run-all.sh
-
-    - name: Resolve logs path
-      if: always()
-      working-directory: tests
-      run: echo "LOGS_PATH=$(readlink -f logs/latest)" >> $GITHUB_ENV
-
-    - name: Publish logs
-      uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: sipssert-logs
-        path: ${{ env.LOGS_PATH }}
+      uses: sobomax/SIPssert/actions/Run_All_Tests@main


### PR DESCRIPTION
This corresponds to the PR https://github.com/OpenSIPS/SIPssert/pull/17 and depends on https://github.com/OpenSIPS/SIPssert/pull/16. Once the latter is cleared, `uses: sobomax/SIPssert` will be replaced with `uses: OpenSIPS/SIPssert` and the PR moved into ready to merge.