### PR TITLE
Split tests into individual jobs.

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,15 +6,33 @@ on:
   pull_request:
 
 jobs:
+  setup-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+
+    - name: Prepare SIPssert
+      uses: OpenSIPS/SIPssert/actions/Prepare_SIPssert@main
+
+    - name: Read and parse YAML file
+      id: set-matrix
+      uses: ./sipssert/actions/Set_Matrix
 
   test:
+    needs: setup-matrix
 
-    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{fromJson(needs.setup-matrix.outputs.matrix)}}
+
+    runs-on: ${{ matrix.os }}
 
     steps:
 
     - name: Prepare SIPssert
       uses: OpenSIPS/SIPssert/actions/Prepare_SIPssert@main
 
-    - name: Run All Tests
-      uses: OpenSIPS/SIPssert/actions/Run_All_Tests@main
+    - name: Run Test
+      uses: ./sipssert/actions/Run_Test
+      with:
+        scenario: ${{ matrix.scenario }}

--- a/matrix.yml
+++ b/matrix.yml
@@ -1,0 +1,15 @@
+os:
+  - ubuntu-latest
+scenario:
+  - accounting
+  - auth
+  - b2b
+  - dialog
+  - permissions
+  - presence
+  - record-route
+  - registration
+  - startup
+  - stir-shaken
+  - topology-hiding
+  - uac-auth


### PR DESCRIPTION
This is part I of two part PR (the other part is in the [OpenSIPS/SIPssert repo](https://github.com/OpenSIPS/SIPssert/pull/20)). It basically splits one monolithic job into individual scenarios to run in parallel. This has the following benefits:

- Test complete much faster. From 30 minutes down to 6-7 minutes;
- Logs are split on per-scenario basis making debugging much easier;
- If one of many scenarios fail, it's very obviously where it fails;
- Different OS/OpenSIPS versions can be tested in parallel if needed.

The matrix is controlled by the matrix.yml file in the root of the tests repo.

![ScreenShot1138](https://github.com/OpenSIPS/sipssert-opensips-tests/assets/218662/dff26eda-8e86-447e-89f7-26b57189350f)
![ScreenShot1139](https://github.com/OpenSIPS/sipssert-opensips-tests/assets/218662/556580e2-b69f-4242-bced-e5708189d732)
