### PR TITLE
httpd: fix MI access from opensips-mi containers + CI improvements

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Get the required OpenSIPS Modules
       id: fetch_modules

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -24,7 +24,7 @@ jobs:
     steps:
 
     - name: Checkout Tests repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ github.repository }}
         path: tests
@@ -59,13 +59,13 @@ jobs:
     if: always()
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ${{ github.repository }}
         path: tests
 
     - name: Download All Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       with:
         path: junit-reports
 
@@ -78,13 +78,13 @@ jobs:
         OUTPUT_FILE: junit-final-report.xml
 
     - name: Upload JUnit XML
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: junit-final-report
         path: junit-final-report.xml
 
     - name: Print tests summary
-      uses: mikepenz/action-junit-report@v5
+      uses: mikepenz/action-junit-report@v6
       id: summary
       if: success() || failure()
       with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Checkout Tests repo
       uses: actions/checkout@v4
       with:
-        repository: OpenSIPS/sipssert-opensips-tests
+        repository: ${{ github.repository }}
         path: tests
 
     - name: Read and parse YAML file
@@ -46,7 +46,7 @@ jobs:
       uses: OpenSIPS/SIPssert/.github/actions/Prepare_SIPssert@main
       with:
         sipssert-repo: OpenSIPS/SIPSsert
-        tests-repo: OpenSIPS/sipssert-opensips-tests
+        tests-repo: ${{ github.repository }}
 
     - name: Run Test
       uses: OpenSIPS/SIPssert/.github/actions/Run_Tests@main
@@ -61,7 +61,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
       with:
-        repository: OpenSIPS/sipssert-opensips-tests
+        repository: ${{ github.repository }}
         path: tests
 
     - name: Download All Artifacts

--- a/b2b/02.marketing/opensips.cfg
+++ b/b2b/02.marketing/opensips.cfg
@@ -62,6 +62,7 @@ modparam("b2b_logic", "server_address", "sip:192.168.52.1:5060")
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/b2b/17.refer-unattended-uac-mi/opensips.cfg
+++ b/b2b/17.refer-unattended-uac-mi/opensips.cfg
@@ -61,6 +61,7 @@ modparam("b2b_logic", "server_address", "sip:192.168.52.1:5060")
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/b2b/18.refer-unattended-uas-mi/opensips.cfg
+++ b/b2b/18.refer-unattended-uas-mi/opensips.cfg
@@ -61,6 +61,7 @@ modparam("b2b_logic", "server_address", "sip:192.168.52.1:5060")
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/b2b/19.refer-unattended-uac-prov-mi/opensips.cfg
+++ b/b2b/19.refer-unattended-uac-prov-mi/opensips.cfg
@@ -60,6 +60,7 @@ loadmodule "b2b_logic.so"
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/b2b/20.refer-unattended-uas-prov-mi/opensips.cfg
+++ b/b2b/20.refer-unattended-uas-prov-mi/opensips.cfg
@@ -60,6 +60,7 @@ loadmodule "b2b_logic.so"
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/dialog/01.dialog/opensips.cfg
+++ b/dialog/01.dialog/opensips.cfg
@@ -65,6 +65,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/dialog/02.pinging/opensips.cfg
+++ b/dialog/02.pinging/opensips.cfg
@@ -66,6 +66,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/dialog/03.reinvite-pinging/opensips.cfg
+++ b/dialog/03.reinvite-pinging/opensips.cfg
@@ -66,6 +66,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/dialog/04.expire/opensips.cfg
+++ b/dialog/04.expire/opensips.cfg
@@ -66,6 +66,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/dialog/05.reinvite-auth/opensips.cfg
+++ b/dialog/05.reinvite-auth/opensips.cfg
@@ -60,6 +60,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/registration/01.no-db/opensips.cfg
+++ b/registration/01.no-db/opensips.cfg
@@ -56,6 +56,7 @@ loadmodule "registrar.so"
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/registration/02.db/opensips.cfg
+++ b/registration/02.db/opensips.cfg
@@ -60,6 +60,7 @@ loadmodule "registrar.so"
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/registration/03.expire/opensips.cfg
+++ b/registration/03.expire/opensips.cfg
@@ -62,6 +62,7 @@ modparam("registrar", "min_expires", 5)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/registration/04.expire-min/opensips.cfg
+++ b/registration/04.expire-min/opensips.cfg
@@ -62,6 +62,7 @@ modparam("registrar", "min_expires", 10)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/registration/05.expire-max/opensips.cfg
+++ b/registration/05.expire-max/opensips.cfg
@@ -63,6 +63,7 @@ modparam("registrar", "max_expires", 5)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/registration/06.reregister-expire/opensips.cfg
+++ b/registration/06.reregister-expire/opensips.cfg
@@ -62,6 +62,7 @@ modparam("registrar", "min_expires", 5)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/registration/07.limit/opensips.cfg
+++ b/registration/07.limit/opensips.cfg
@@ -63,6 +63,7 @@ modparam("registrar", "max_contacts", 2)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/registration/08.overwrite/opensips.cfg
+++ b/registration/08.overwrite/opensips.cfg
@@ -63,6 +63,7 @@ modparam("registrar", "max_contacts", 1)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/startup/01.default-cfg/opensips.cfg
+++ b/startup/01.default-cfg/opensips.cfg
@@ -92,6 +92,7 @@ modparam("acc", "detect_direction", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/startup/02.gen-residential-cfg/opensips.cfg
+++ b/startup/02.gen-residential-cfg/opensips.cfg
@@ -73,6 +73,7 @@ loadmodule "db_sqlite.so"
 
 #### HTTPD module
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 
 #### USeR LOCation module
 loadmodule "usrloc.so"

--- a/startup/03.gen-trunking-cfg/opensips.cfg
+++ b/startup/03.gen-trunking-cfg/opensips.cfg
@@ -41,6 +41,7 @@ mpath="/usr/lib/x86_64-linux-gnu/opensips/modules/"
 
 #### HTTPD module
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 
 #### SIGNALING module
 loadmodule "signaling.so"

--- a/startup/04.gen-loadbalancer-cfg/opensips.cfg
+++ b/startup/04.gen-loadbalancer-cfg/opensips.cfg
@@ -41,6 +41,7 @@ mpath="/usr/lib/x86_64-linux-gnu/opensips/modules/"
 
 #### HTTPD module
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 
 #### SIGNALING module
 loadmodule "signaling.so"

--- a/stir-shaken/01.auth-simple/opensips.cfg
+++ b/stir-shaken/01.auth-simple/opensips.cfg
@@ -59,6 +59,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 #### Stir and Shaken

--- a/stir-shaken/02.auth-diverted-cached/opensips.cfg
+++ b/stir-shaken/02.auth-diverted-cached/opensips.cfg
@@ -67,6 +67,7 @@ loadmodule "exec.so"
 #modparam("exec", "setvars", 1)
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 loadmodule "cachedb_local.so"

--- a/topology-hiding/03.th-dialog/opensips.cfg
+++ b/topology-hiding/03.th-dialog/opensips.cfg
@@ -69,6 +69,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/topology-hiding/04.th-dialog-username/opensips.cfg
+++ b/topology-hiding/04.th-dialog-username/opensips.cfg
@@ -69,6 +69,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/topology-hiding/05.th-dialog-did/opensips.cfg
+++ b/topology-hiding/05.th-dialog-did/opensips.cfg
@@ -69,6 +69,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########

--- a/topology-hiding/06.th-dialog-callid/opensips.cfg
+++ b/topology-hiding/06.th-dialog-callid/opensips.cfg
@@ -70,6 +70,7 @@ modparam("rr", "append_fromtag", 0)
 loadmodule "proto_udp.so"
 
 loadmodule "httpd.so"
+modparam("httpd", "ip", "192.168.52.1")
 loadmodule "mi_http.so"
 
 ####### Routing Logic ########


### PR DESCRIPTION
## Summary

- **Fix MI access**: `httpd` module defaults to binding on `127.0.0.1`, making it unreachable from `opensips-mi` task containers on the same bridge network. Added `modparam("httpd", "ip", "192.168.52.1")` to all 28 scenarios that use `opensips-mi` tasks.
- **Fix fork CI**: Workflow was hardcoding `OpenSIPS/sipssert-opensips-tests` in all checkout steps and the `Prepare_SIPssert` `tests-repo` input, causing forks to always run tests from upstream instead of their own branch. Replaced with `${{ github.repository }}`.
- **Upgrade GitHub Actions**: Bumped all actions to latest major versions (checkout v6, download-artifact v8, upload-artifact v7, mikepenz/action-junit-report v6).