### PR TITLE
github: also publish image to ghcr.io and pull tests from it

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -9,6 +9,10 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      packages: write
+
     steps:
     - uses: actions/checkout@v6
 
@@ -25,3 +29,4 @@ jobs:
         modules: ${{ steps.fetch_modules.outputs.MODULES }}
         docker-username: ${{ secrets.DOCKER_USERNAME }}
         docker-token: ${{ secrets.DOCKER_TOKEN }}
+        ghcr-token: ${{ secrets.GITHUB_TOKEN }}

--- a/config.yml
+++ b/config.yml
@@ -33,7 +33,7 @@ defaults:
     mi_ip: {{ opensips_ip }}
   opensips:
     ip: {{ opensips_ip }}
-    image: '{{ opensips_image if opensips_image is defined else "opensips/opensips:sipssert" ~ ("-" ~ opensips_version if opensips_version is defined else "") }}'
+    image: '{{ opensips_image if opensips_image is defined else "ghcr.io/opensips/opensips:sipssert" ~ ("-" ~ opensips_version if opensips_version is defined else "") }}'
     socket: udp:{{ opensips_ip }}:{{ opensips_port }}
     stop_timeout: 5
   mysql:


### PR DESCRIPTION
## Changes

- Pass `ghcr-token` (the built-in `GITHUB_TOKEN`) to the `docker-opensips-publish` action and grant the `publish` job `packages: write`, so the built image is mirrored to `ghcr.io/opensips/opensips:<tag>` alongside Docker Hub. The action already had the GHCR login/tag/push steps; they were skipped because no token was passed.
- Switch the default OpenSIPS test image in `config.yml` to `ghcr.io/opensips/opensips:sipssert` so conformance tests pull from GHCR.